### PR TITLE
A-Assertions: Add assertions to check for null variables

### DIFF
--- a/src/main/java/eltry/Parsers.java
+++ b/src/main/java/eltry/Parsers.java
@@ -14,21 +14,27 @@ public class Parsers {
      * @throws EltryException if the input is invalid or the format is incorrect
      */
     public Command parse(String input) throws EltryException {
+        assert input != null : "Input string should never be null";
+
         if (input.equalsIgnoreCase("bye")) {
             return new Command("bye");
         } else if (input.equalsIgnoreCase("list")) {
             return new Command("list");
         } else if (input.toLowerCase().startsWith("mark ")) {
             int index = parseIndex(input);
+            assert index >= 0 : "Parsed index for mark should be non-negative";
             return new Command("mark", index);
         } else if (input.toLowerCase().startsWith("unmark ")) {
             int index = parseIndex(input);
+            assert index >= 0 : "Parsed index for unmark should be non-negative";
             return new Command("unmark", index);
         } else if (input.toLowerCase().startsWith("delete ")) {
             int index = parseIndex(input);
+            assert index >= 0 : "Parsed index for delete should be non-negative";
             return new Command("delete", index);
         } else if (input.toLowerCase().startsWith("todo")) {
             String desc = input.substring(4).trim();
+            assert desc != null : "Description for todo should not be null";
             if (desc.isEmpty()) throw new EltryException("The description of a todo cannot be empty.");
             return new Command("todo", desc);
         } else if (input.toLowerCase().startsWith("deadline")) {
@@ -39,6 +45,7 @@ public class Parsers {
             }
             String desc = rest.substring(0, byIndex).trim();
             String byStr = rest.substring(byIndex + 3).trim();
+            assert desc != null && byStr != null : "Deadline description and date must not be null";
             if (desc.isEmpty() || byStr.isEmpty()) {
                 throw new EltryException("Description and deadline cannot be empty.");
             }
@@ -53,12 +60,14 @@ public class Parsers {
             String desc = rest.substring(0, fromIndex).trim();
             String fromStr = rest.substring(fromIndex + 5, toIndex).trim();
             String toStr = rest.substring(toIndex + 4).trim();
+            assert desc != null && fromStr != null && toStr != null : "Event fields must not be null";
             if (desc.isEmpty() || fromStr.isEmpty() || toStr.isEmpty()) {
                 throw new EltryException("Description, start, and end cannot be empty.");
             }
             return new Command("event", desc, fromStr, toStr);
         } else if (input.toLowerCase().startsWith("find ")) {
             String keyword = input.substring(5).trim();
+            assert keyword != null : "Keyword must not be null";
             if (keyword.isEmpty()) throw new EltryException("Keyword cannot be empty.");
             return new Command("find", keyword);
         } else {
@@ -74,10 +83,12 @@ public class Parsers {
      * @throws EltryException if the index is missing, not a number, or invalid
      */
     private int parseIndex(String input) throws EltryException {
+        assert input != null : "Input for parseIndex should not be null";
         try {
             String[] parts = input.split(" ", 2);
+            assert parts.length == 2 : "Index-based commands must have two parts";
             int index = Integer.parseInt(parts[1]) - 1;
-            if (index < 0) throw new EltryException("Invalid task number.");
+            assert index >= 0 : "Index must not be negative";
             return index;
         } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
             throw new EltryException("Usage: mark/unmark/delete <task_number>");


### PR DESCRIPTION
Parsers relies on the assumption that input strings and extracted fields (e.g. descriptions, keywords, and date/time values) are never null.

Leaving these assumptions implicit risks silent failures or unexpected NullPointerExceptions if future changes pass null values.